### PR TITLE
Add an arn argument so that we can use submit-monitor for community events

### DIFF
--- a/utils/submit-monitor.py
+++ b/utils/submit-monitor.py
@@ -25,12 +25,12 @@ def main():
     try:
         opts, _ = getopt.getopt(
             sys.argv[1:],
-            "lvsghm:b:",
-            ["logs", "verbose", "summary", "graphics", "help", "model=", "board="],
+            "lvsghm:b:a:",
+            ["logs", "verbose", "summary", "graphics", "help", "model=", "board=", "arn="],
         )
     except getopt.GetoptError as err:
         # print help information and exit:
-        print(err)  # will print something like "option -a not recognized"
+        print(err)  # will print something like "option -x not recognized"
         usage()
         sys.exit(2)
 
@@ -42,6 +42,7 @@ def main():
     create_summary = False
     model_name = None
     leaderboard_guid = None
+    leaderboard_arn = None
 
     for opt, arg in opts:
         if opt in ("-l", "--logs"):
@@ -56,6 +57,8 @@ def main():
             model_name = arg.strip()
         elif opt in ("-b", "--board"):
             leaderboard_guid = arg.strip()
+        elif opt in ("-a", "--arn"):
+            leaderboard_arn = arg.strip()
         elif opt in ("-h", "--help"):
             usage()
             sys.exit()
@@ -81,7 +84,8 @@ def main():
         sys.exit(1)
 
     # Find the leaderboard
-    leaderboard_arn = find_leaderboard(leaderboard_guid)
+    if not leaderboard_arn:
+      leaderboard_arn = find_leaderboard(leaderboard_guid)
 
     if leaderboard_arn is not None:
         if verbose:
@@ -306,6 +310,7 @@ def usage():
     print("        -g                Download video recordings.")
     print("        -m                Display name of the model to submit.")
     print("        -b                GUID (not ARN) of the leaderboard to submit to.")
+    print("        -a                ARN  of the leaderboard to submit to.")
     sys.exit(1)
 
 

--- a/utils/submit-monitor.py
+++ b/utils/submit-monitor.py
@@ -85,7 +85,7 @@ def main():
 
     # Find the leaderboard
     if not leaderboard_arn:
-      leaderboard_arn = find_leaderboard(leaderboard_guid)
+        leaderboard_arn = find_leaderboard(leaderboard_guid)
 
     if leaderboard_arn is not None:
         if verbose:

--- a/utils/submit-monitor.py
+++ b/utils/submit-monitor.py
@@ -26,7 +26,7 @@ def main():
         opts, _ = getopt.getopt(
             sys.argv[1:],
             "lvsghm:b:",
-            ["logs", "verbose", "summary", "graphics", "help", "model=", "board=", "arn="],
+            ["logs", "verbose", "summary", "graphics", "help", "model=", "board="],
         )
     except getopt.GetoptError as err:
         # print help information and exit:
@@ -311,7 +311,6 @@ def usage():
     print("        -g                Download video recordings.")
     print("        -m                Display name of the model to submit.")
     print("        -b                GUID or ARN of the leaderboard to submit to.")
-    print("        -a                ARN  of the leaderboard to submit to.")
     sys.exit(1)
 
 

--- a/utils/submit-monitor.py
+++ b/utils/submit-monitor.py
@@ -25,7 +25,7 @@ def main():
     try:
         opts, _ = getopt.getopt(
             sys.argv[1:],
-            "lvsghm:b:a:",
+            "lvsghm:b:",
             ["logs", "verbose", "summary", "graphics", "help", "model=", "board=", "arn="],
         )
     except getopt.GetoptError as err:
@@ -57,8 +57,6 @@ def main():
             model_name = arg.strip()
         elif opt in ("-b", "--board"):
             leaderboard_guid = arg.strip()
-        elif opt in ("-a", "--arn"):
-            leaderboard_arn = arg.strip()
         elif opt in ("-h", "--help"):
             usage()
             sys.exit()
@@ -82,6 +80,9 @@ def main():
     else:
         print("Did not find model with name {}".format(model_name))
         sys.exit(1)
+
+    if leaderboard_guid.startswith('arn'):
+        leaderboard_arn = leaderboard_guid
 
     # Find the leaderboard
     if not leaderboard_arn:
@@ -309,7 +310,7 @@ def usage():
     print("        -l                Download robomaker logfiles.")
     print("        -g                Download video recordings.")
     print("        -m                Display name of the model to submit.")
-    print("        -b                GUID (not ARN) of the leaderboard to submit to.")
+    print("        -b                GUID or ARN of the leaderboard to submit to.")
     print("        -a                ARN  of the leaderboard to submit to.")
     sys.exit(1)
 


### PR DESCRIPTION
Adding ARN as a parameter since GUID is not enough for community events where the ARN needs to have the AWS Account Number of the account that created the community race. 