### PR TITLE
Update to docker-compose

### DIFF
--- a/docker/docker-compose-local.yml
+++ b/docker/docker-compose-local.yml
@@ -1,4 +1,3 @@
-
 version: '3.7'
 
 networks:
@@ -11,8 +10,8 @@ services:
     image: minio/minio
     ports:
       - "9000:9000"
-      - "9001:9001"
-    command: server /data --console-address ":9001"
+      - "9001:9443"
+    command: server /data --console-address ":9443"
     environment:
       - MINIO_ROOT_USER=${DR_LOCAL_ACCESS_KEY_ID}
       - MINIO_ROOT_PASSWORD=${DR_LOCAL_SECRET_ACCESS_KEY}


### PR DESCRIPTION
Fixes so latest version of minio will run properly. Putting console at 9001 with internal map to 9443