### PR TITLE
Additional tweak for non-standard-region

### DIFF
--- a/bin/activate.sh
+++ b/bin/activate.sh
@@ -44,6 +44,10 @@ function dr-update-env {
     export DR_ROBOMAKER_GUI_PORT="5901-5920"
   fi
 
+  # Setting the default region to ensure that things work also in the
+  # non default regions.
+  export AWS_DEFAULT_REGION=${DR_AWS_APP_REGION}
+
 }
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"


### PR DESCRIPTION
Ensure the `AWS_DEFAULT_REGION` is set to the DR_AWS_APP_REGION.