### PR TITLE
nividia-driver-550 for Ubuntu22.04

### DIFF
--- a/bin/prepare.sh
+++ b/bin/prepare.sh
@@ -55,7 +55,7 @@ fi
 if [[ "${ARCH}" == "gpu" && -z "${IS_WSL2}" ]]; then
     case $distribution in
     ubuntu2004)
-        sudo apt install -y nvidia-driver-550 --no-install-recommends -o Dpkg::Options::="--force-overwrite"
+        sudo apt install -y nvidia-driver-525-server --no-install-recommends -o Dpkg::Options::="--force-overwrite"
         ;;
     ubuntu2204)
         sudo apt install -y nvidia-driver-550 --no-install-recommends -o Dpkg::Options::="--force-overwrite"

--- a/bin/prepare.sh
+++ b/bin/prepare.sh
@@ -55,10 +55,10 @@ fi
 if [[ "${ARCH}" == "gpu" && -z "${IS_WSL2}" ]]; then
     case $distribution in
     ubuntu2004)
-        sudo apt install -y nvidia-driver-525-server --no-install-recommends -o Dpkg::Options::="--force-overwrite"
+        sudo apt install -y nvidia-driver-550 --no-install-recommends -o Dpkg::Options::="--force-overwrite"
         ;;
     ubuntu2204)
-        sudo apt install -y nvidia-driver-535-server --no-install-recommends -o Dpkg::Options::="--force-overwrite"
+        sudo apt install -y nvidia-driver-550 --no-install-recommends -o Dpkg::Options::="--force-overwrite"
         ;;
     *)
         echo "Unsupported distribution: $distribution"


### PR DESCRIPTION
Tested using g4dn, g5 and g6 instances in AWS using Ubuntu2204.  All working in testing, and in extended testing (24 hours) on the G6 instances the instances aren't hanging and becoming unresponsive as they were before.

nvidia-driver-550 is the recommended version to run when querying the instances using the nvidia tools.  There is no 'nvidia-driver-550-server'  version.