### PR TITLE
Fix: Replacing unsupported flag on docker compose command

### DIFF
--- a/scripts/training/start.sh
+++ b/scripts/training/start.sh
@@ -190,6 +190,7 @@ if [[ "${DR_DOCKER_STYLE,,}" == "swarm" ]]; then
   DISPLAY=$ROBO_DISPLAY docker stack deploy $COMPOSE_FILES $STACK_NAME
 
 else
+  COMPOSE_FILES=$(echo "$COMPOSE_FILES" | sed 's/\(\s\|^\)-c\(\s\|$\)/ -f /g')
   DISPLAY=$ROBO_DISPLAY docker compose $COMPOSE_FILES -p $STACK_NAME up -d --scale robomaker=$DR_WORKERS
 fi
 


### PR DESCRIPTION
Fixing the error `unsupported flag -c` on `docker compose` up command. This error happened because var`COMPOSE_FILES ` was working well to `swarm` but not to the else (`compose`) case on this check `if [[ "${DR_DOCKER_STYLE,,}" == "swarm" ]];`. The `docker compose` uses a different flag to up multiple docker images.

The solution replaces the `-c` occurrences with `-f`.