### PR TITLE
Update Ubuntu22.04 GPU drivers and add docker var to fix opengl cpu training

### DIFF
--- a/bin/prepare.sh
+++ b/bin/prepare.sh
@@ -58,7 +58,7 @@ if [[ "${ARCH}" == "gpu" && -z "${IS_WSL2}" ]]; then
         sudo apt install -y nvidia-driver-525-server --no-install-recommends -o Dpkg::Options::="--force-overwrite"
         ;;
     ubuntu2204)
-        sudo apt install -y nvidia-driver-535-server --no-install-recommends -o Dpkg::Options::="--force-overwrite"
+        sudo apt install -y nvidia-driver-550 --no-install-recommends -o Dpkg::Options::="--force-overwrite"
         ;;
     *)
         echo "Unsupported distribution: $distribution"

--- a/docker/docker-compose-local-xorg.yml
+++ b/docker/docker-compose-local-xorg.yml
@@ -7,6 +7,7 @@ services:
       - USE_EXTERNAL_X=${DR_HOST_X}
       - XAUTHORITY=/root/.Xauthority
       - QT_X11_NO_MITSHM=1
+      - NVIDIA_DRIVER_CAPABILITIES=all
     volumes:
       - '/tmp/.X11-unix/:/tmp/.X11-unix'
       - '${XAUTHORITY}:/root/.Xauthority'


### PR DESCRIPTION
@larsll tested ok on a ~18 hour run, suggest we merge and see if it also fixes the stability issue we've experienced on g6 instances?