### PR TITLE
Add AWS IMDS query env vars

### DIFF
--- a/docker/docker-compose-training.yml
+++ b/docker/docker-compose-training.yml
@@ -21,6 +21,8 @@ services:
       - MODELMETADATA_FILE_S3_KEY=${DR_LOCAL_S3_MODEL_METADATA_KEY}
       - CUDA_VISIBLE_DEVICES=${DR_SAGEMAKER_CUDA_DEVICES:-}
       - MAX_MEMORY_STEPS=${DR_TRAIN_MAX_STEPS_PER_ITERATION:-}
+      - AWS_METADATA_SERVICE_TIMEOUT=3
+      - AWS_METADATA_SERVICE_NUM_ATTEMPTS=5
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
       - "/tmp/sagemaker:/tmp/sagemaker"
@@ -47,4 +49,6 @@ services:
       - GAZEBO_ARGS=${DR_GAZEBO_ARGS:-}
       - TELEGRAF_HOST=${DR_TELEGRAF_HOST:-}
       - TELEGRAF_PORT=${DR_TELEGRAF_PORT:-}
+      - AWS_METADATA_SERVICE_TIMEOUT=3
+      - AWS_METADATA_SERVICE_NUM_ATTEMPTS=5
     init: true


### PR DESCRIPTION
Add AWS IMDS query vars in attempt to fix s3 timeout issue that occurs intermittently and ends training.

Ran for two days with no adverse affects and no s3 timeout issues (although the issue is intermittent enough that this doesn't guaranteed yet that it's fixed it for sure)

@larsll do you want to test local / minio before merging?