### PR TITLE
AWS Metaservice Timeout and Retry Variables

### DIFF
--- a/bin/activate.sh
+++ b/bin/activate.sh
@@ -120,6 +120,10 @@ elif [[ "${DR_CLOUD,,}" == "remote" ]]; then
   DR_TRAIN_COMPOSE_FILE="$DR_DOCKER_FILE_SEP $DIR/docker/docker-compose-training.yml $DR_DOCKER_FILE_SEP $DIR/docker/docker-compose-endpoint.yml"
   DR_EVAL_COMPOSE_FILE="$DR_DOCKER_FILE_SEP $DIR/docker/docker-compose-eval.yml $DR_DOCKER_FILE_SEP $DIR/docker/docker-compose-endpoint.yml"
   DR_MINIO_COMPOSE_FILE=""
+elif [[ "${DR_CLOUD,,}" == "aws" ]]; then
+  DR_LOCAL_PROFILE_ENDPOINT_URL=""
+  DR_TRAIN_COMPOSE_FILE="$DR_DOCKER_FILE_SEP $DIR/docker/docker-compose-training.yml $DR_DOCKER_FILE_SEP $DIR/docker/docker-compose-aws.yml"
+  DR_EVAL_COMPOSE_FILE="$DR_DOCKER_FILE_SEP $DIR/docker/docker-compose-eval.yml $DR_DOCKER_FILE_SEP $DIR/docker/docker-compose-aws.yml"
 else
   DR_LOCAL_PROFILE_ENDPOINT_URL=""
   DR_TRAIN_COMPOSE_FILE="$DR_DOCKER_FILE_SEP $DIR/docker/docker-compose-training.yml"

--- a/docker/docker-compose-aws.yml
+++ b/docker/docker-compose-aws.yml
@@ -1,0 +1,11 @@
+version: '3.7'
+
+services:
+  rl_coach:
+    environment:
+      - AWS_METADATA_SERVICE_TIMEOUT=3
+      - AWS_METADATA_SERVICE_NUM_ATTEMPTS=5
+  robomaker:
+    environment:
+      - AWS_METADATA_SERVICE_TIMEOUT=3
+      - AWS_METADATA_SERVICE_NUM_ATTEMPTS=5


### PR DESCRIPTION
Testing with this branch: -
![image](https://github.com/aws-deepracer-community/deepracer-for-cloud/assets/53598199/98a5e965-424c-4ec6-ab53-f19f59ed1b6d)

AWS robomkaer with env vars: -
![image](https://github.com/aws-deepracer-community/deepracer-for-cloud/assets/53598199/a7a55b17-9e0e-416a-9bee-c19b42e22ba5)

AWS rlcoach with env vars: -
![image](https://github.com/aws-deepracer-community/deepracer-for-cloud/assets/53598199/641621df-1be7-46f3-944b-d77597d2bf3c)


Neither var is set when using local setup with minio: -
![image](https://github.com/aws-deepracer-community/deepracer-for-cloud/assets/53598199/c5bb13ef-57a5-45e5-a489-7d40659bcad4)
