### PR TITLE
physical car upload fix for combined image

### DIFF
--- a/scripts/upload/upload-car.sh
+++ b/scripts/upload/upload-car.sh
@@ -36,7 +36,7 @@ done
 # The file is created directly from within the sagemaker container, using the most recent checkpoint
 
 # Find name of sagemaker container
-SAGEMAKER_CONTAINERS=$(docker ps | awk ' /sagemaker/ { print $1 } ' | xargs)
+SAGEMAKER_CONTAINERS=$(docker ps | awk ' /algo/ { print $1 } ' | xargs)
 if [[ -n $SAGEMAKER_CONTAINERS ]]; then
     for CONTAINER in $SAGEMAKER_CONTAINERS; do
         CONTAINER_NAME=$(docker ps --format '{{.Names}}' --filter id=$CONTAINER)


### PR DESCRIPTION
Container for sagemaker no longer has sagemaker in the name, so physical car upload no longer works without a fix.  Update script to look for the container with 'algo' in the name.

Car upload before: -
![image](https://github.com/user-attachments/assets/66f5fe0a-c3d7-4e98-8d76-235ab1d0118a)


Car upload after: -
![image](https://github.com/user-attachments/assets/9d78be4d-a7d4-4865-96b0-9b273e65ef55)
