### PR TITLE
Improved car zip creation

### DIFF
--- a/bin/init.sh
+++ b/bin/init.sh
@@ -101,7 +101,7 @@ cd $INSTALL_DIR
 
 # create directory structure for docker volumes
 mkdir -p $INSTALL_DIR/data $INSTALL_DIR/data/minio $INSTALL_DIR/data/minio/bucket
-mkdir -p $INSTALL_DIR/data/logs $INSTALL_DIR/data/analysis $INSTALL_DIR/data/scripts $INSTALL_DIR/tmp
+mkdir -p $INSTALL_DIR/data/logs $INSTALL_DIR/data/analysis $INSTALL_DIR/data/scripts $INSTALL_DIR/data/output $INSTALL_DIR/tmp
 sudo mkdir -p /tmp/sagemaker
 sudo chmod -R g+w /tmp/sagemaker
 

--- a/bin/scripts_wrapper.sh
+++ b/bin/scripts_wrapper.sh
@@ -92,6 +92,10 @@ function dr-download-model {
   dr-update-env && ${DR_DIR}/scripts/upload/download-model.sh "$@"
 }
 
+function dr-create-car-zip {
+  dr-update-env && ${DR_DIR}/scripts/upload/create-car-zip.sh "$@"
+}
+
 function dr-upload-car-zip {
   dr-update-env && ${DR_DIR}/scripts/upload/upload-car.sh "$@"
 }

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -103,3 +103,5 @@ The scripts assume that two files `system.env` containing constant configuration
 | `dr-set-upload-model` | Updates the `run.env` with the prefix and name of your selected model. |
 | `dr-upload-model` | Uploads the model defined in `DR_LOCAL_S3_MODEL_PREFIX` to the AWS DeepRacer S3 prefix defined in `DR_UPLOAD_S3_PREFIX` |
 | `dr-download-model` | Downloads a file from a 'real' S3 location into a local prefix of choice. |
+| `dr-create-car-zip` | Creates a physical car deployment archive (`data/output/<model-prefix>.tar.gz`) containing `agent/model.pb` and `model_metadata.json`, sourced directly from S3 — no running container required. Accepts `-b` (best checkpoint, default: last), `-p <prefix>` (override model prefix), `-o <output-file>`. |
+| `dr-upload-car-zip` | Creates a car deployment archive via `dr-create-car-zip` and uploads it to S3. Accepts `-b` (best checkpoint), `-f` (force, skip confirmation), `-L` (upload to local S3 bucket), `-p <prefix>` (override model prefix). |

--- a/scripts/upload/create-car-zip.sh
+++ b/scripts/upload/create-car-zip.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+usage() {
+  echo "Usage: $0 [-b] [-p <model-prefix>] [-o <output-file>]"
+  echo "       -b              Use best checkpoint. Default is last checkpoint."
+  echo "       -p <prefix>     Model prefix. Default: DR_LOCAL_S3_MODEL_PREFIX."
+  echo "       -o <output>     Output file path. Default: <DR_DIR>/<model-prefix>.tar.gz"
+  exit 1
+}
+
+trap ctrl_c INT
+
+function ctrl_c() {
+  echo "Requested to stop."
+  exit 1
+}
+
+while getopts ":bp:o:h" opt; do
+  case $opt in
+  b)
+    OPT_CHECKPOINT="best"
+    ;;
+  p)
+    OPT_PREFIX="$OPTARG"
+    ;;
+  o)
+    OPT_OUTPUT="$OPTARG"
+    ;;
+  h)
+    usage
+    ;;
+  \?)
+    echo "Invalid option -$OPTARG" >&2
+    usage
+    ;;
+  esac
+done
+
+# Determine model prefix
+if [[ -n "${OPT_PREFIX}" ]]; then
+  MODEL_PREFIX="${OPT_PREFIX}"
+elif [[ -n "${DR_LOCAL_S3_MODEL_PREFIX}" ]]; then
+  MODEL_PREFIX="${DR_LOCAL_S3_MODEL_PREFIX}"
+else
+  echo "No model prefix specified and DR_LOCAL_S3_MODEL_PREFIX is not set." >&2
+  exit 1
+fi
+
+# Determine output file
+if [[ -n "${OPT_OUTPUT}" ]]; then
+  OUTPUT_FILE="${OPT_OUTPUT}"
+else
+  mkdir -p "${DR_DIR}/data/output"
+  OUTPUT_FILE="${DR_DIR}/data/output/${MODEL_PREFIX}.tar.gz"
+fi
+
+SOURCE_S3_BUCKET="${DR_LOCAL_S3_BUCKET}"
+
+cd "${DR_DIR}"
+WORK_DIR="${DR_DIR}/tmp/car_zip/"
+rm -rf "${WORK_DIR}" && mkdir -p "${WORK_DIR}model" "${WORK_DIR}agent"
+
+# Download checkpoint index
+echo "Fetching checkpoint info from s3://${SOURCE_S3_BUCKET}/${MODEL_PREFIX}/model/"
+aws ${DR_LOCAL_PROFILE_ENDPOINT_URL} s3 cp \
+  "s3://${SOURCE_S3_BUCKET}/${MODEL_PREFIX}/model/deepracer_checkpoints.json" \
+  "${WORK_DIR}model/" --no-progress
+
+if [ ! -f "${WORK_DIR}model/deepracer_checkpoints.json" ]; then
+  echo "deepracer_checkpoints.json not found at s3://${SOURCE_S3_BUCKET}/${MODEL_PREFIX}/model/. Exiting." >&2
+  exit 1
+fi
+
+CHECKPOINT_INDEX="${WORK_DIR}model/deepracer_checkpoints.json"
+
+# Select checkpoint
+if [[ "${OPT_CHECKPOINT}" == "best" ]]; then
+  echo "Using best checkpoint"
+  CHECKPOINT_FILE=$(jq -r .best_checkpoint.name < "${CHECKPOINT_INDEX}")
+else
+  echo "Using last checkpoint"
+  CHECKPOINT_FILE=$(jq -r .last_checkpoint.name < "${CHECKPOINT_INDEX}")
+fi
+
+if [[ -z "${CHECKPOINT_FILE}" || "${CHECKPOINT_FILE}" == "null" ]]; then
+  echo "Could not determine checkpoint from deepracer_checkpoints.json. Exiting." >&2
+  exit 1
+fi
+
+CHECKPOINT=$(echo "${CHECKPOINT_FILE}" | cut -f1 -d_)
+echo "Selected checkpoint: ${CHECKPOINT} (${CHECKPOINT_FILE})"
+
+# Download model.pb and model_metadata.json
+echo "Downloading model_${CHECKPOINT}.pb ..."
+aws ${DR_LOCAL_PROFILE_ENDPOINT_URL} s3 cp \
+  "s3://${SOURCE_S3_BUCKET}/${MODEL_PREFIX}/model/model_${CHECKPOINT}.pb" \
+  "${WORK_DIR}agent/model.pb" --no-progress
+
+echo "Downloading model_metadata.json ..."
+aws ${DR_LOCAL_PROFILE_ENDPOINT_URL} s3 cp \
+  "s3://${SOURCE_S3_BUCKET}/${MODEL_PREFIX}/model/model_metadata.json" \
+  "${WORK_DIR}model_metadata.json" --no-progress
+
+if [ ! -f "${WORK_DIR}agent/model.pb" ]; then
+  echo "model_${CHECKPOINT}.pb not found in S3. Exiting." >&2
+  exit 1
+fi
+
+if [ ! -f "${WORK_DIR}model_metadata.json" ]; then
+  echo "model_metadata.json not found in S3. Exiting." >&2
+  exit 1
+fi
+
+# Create tar.gz with the expected on-car structure:
+#   agent/model.pb
+#   model_metadata.json
+echo "Creating ${OUTPUT_FILE} ..."
+tar -czf "${OUTPUT_FILE}" \
+  -C "${WORK_DIR}" \
+  agent/model.pb model_metadata.json
+
+echo "Car zip created: ${OUTPUT_FILE}"

--- a/scripts/upload/upload-car.sh
+++ b/scripts/upload/upload-car.sh
@@ -1,78 +1,86 @@
 #!/usr/bin/env bash
 
 usage() {
-    echo "Usage: $0 [-L] [-f]"
-    echo "       -f        Force. Do not ask for confirmation."
-    echo "       -L        Upload model to the local S3 bucket."
-    exit 1
+  echo "Usage: $0 [-b] [-f] [-L] [-p <model-prefix>]"
+  echo "       -b              Use best checkpoint. Default is last checkpoint."
+  echo "       -f              Force. Do not ask for confirmation."
+  echo "       -L              Upload to local S3 bucket."
+  echo "       -p <prefix>     Model prefix. Default: DR_LOCAL_S3_MODEL_PREFIX."
+  exit 1
 }
 
 trap ctrl_c INT
 
 function ctrl_c() {
-    echo "Requested to stop."
-    exit 1
+  echo "Requested to stop."
+  exit 1
 }
 
-while getopts ":Lf" opt; do
-    case $opt in
-    L)
-        OPT_LOCAL="Local"
-        ;;
-    f)
-        OPT_FORCE="force"
-        ;;
-    h)
-        usage
-        ;;
-    \?)
-        echo "Invalid option -$OPTARG" >&2
-        usage
-        ;;
-    esac
+while getopts ":bfLp:h" opt; do
+  case $opt in
+  b)
+    OPT_CHECKPOINT="-b"
+    ;;
+  f)
+    OPT_FORCE="force"
+    ;;
+  L)
+    OPT_LOCAL="Local"
+    ;;
+  p)
+    OPT_PREFIX="$OPTARG"
+    ;;
+  h)
+    usage
+    ;;
+  \?)
+    echo "Invalid option -$OPTARG" >&2
+    usage
+    ;;
+  esac
 done
 
-# This script creates the tar.gz file necessary to operate inside a deepracer physical car
-# The file is created directly from within the sagemaker container, using the most recent checkpoint
-
-# Find name of sagemaker container
-SAGEMAKER_CONTAINERS=$(docker ps | awk ' /algo/ { print $1 } ' | xargs)
-if [[ -n $SAGEMAKER_CONTAINERS ]]; then
-    for CONTAINER in $SAGEMAKER_CONTAINERS; do
-        CONTAINER_NAME=$(docker ps --format '{{.Names}}' --filter id=$CONTAINER)
-        CONTAINER_PREFIX=$(echo $CONTAINER_NAME | perl -n -e'/(.*)_(algo(.*))_./; print $1')
-        echo "Found Sagemaker container: $CONTAINER_NAME"
-    done
-fi
-
-#create tmp directory if it doesnt already exit
-mkdir -p $DR_DIR/tmp/car_upload
-cd $DR_DIR/tmp/car_upload
-#ensure directory is empty
-rm -r $DR_DIR/tmp/car_upload/*
-#The files we want are located inside the sagemaker container at /opt/ml/model.  Copy them to the tmp directory
-docker cp $CONTAINER_NAME:/opt/ml/model $DR_DIR/tmp/car_upload
-cd $DR_DIR/tmp/car_upload/model
-#create a tar.gz file containing all of these files
-tar -czvf carfile.tar.gz *
-
-# Upload files
-if [[ -z "${OPT_FORCE}" ]]; then
-    if [[ -n "${OPT_LOCAL}" ]]; then
-        echo "Ready to upload car model to local s3://${DR_LOCAL_S3_BUCKET}/${DR_UPLOAD_S3_PREFIX}."
-    else
-        echo "Ready to upload car model to remote s3://${DR_UPLOAD_S3_BUCKET}/${DR_UPLOAD_S3_PREFIX}."
-    fi
-    read -r -p "Are you sure? [y/N] " response
-    if [[ ! "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
-        echo "Aborting."
-        exit 1
-    fi
-fi
-
-#upload to s3
-if [[ -n "${OPT_LOCAL}" ]]; then
-    aws ${DR_LOCAL_PROFILE_ENDPOINT_URL} s3 cp carfile.tar.gz s3://${DR_LOCAL_S3_BUCKET}/${DR_UPLOAD_S3_PREFIX}/carfile.tar.gz
+# Determine model prefix
+if [[ -n "${OPT_PREFIX}" ]]; then
+  MODEL_PREFIX="${OPT_PREFIX}"
 else
-    aws ${DR_UPLOAD_PROFILE} s3 cp carfile.tar.gz s3://${DR_UPLOAD_S3_BUCKET}/${DR_UPLOAD_S3_PREFIX}/carfile.tar.gz
+  MODEL_PREFIX="${DR_LOCAL_S3_MODEL_PREFIX}"
 fi
+
+# Create the car tar.gz via create-car-zip.sh
+CREATE_ARGS="${OPT_CHECKPOINT}"
+if [[ -n "${OPT_PREFIX}" ]]; then
+  CREATE_ARGS="${CREATE_ARGS} -p ${OPT_PREFIX}"
+fi
+
+CAR_ZIP_FILE="${DR_DIR}/${MODEL_PREFIX}.tar.gz"
+CREATE_ARGS="${CREATE_ARGS} -o ${CAR_ZIP_FILE}"
+
+${DR_DIR}/scripts/upload/create-car-zip.sh ${CREATE_ARGS}
+if [ $? -ne 0 ]; then
+  echo "Failed to create car zip. Exiting." >&2
+  exit 1
+fi
+
+# Determine upload target
+if [[ -z "${OPT_LOCAL}" ]]; then
+  TARGET_S3_BUCKET="${DR_UPLOAD_S3_BUCKET}"
+  UPLOAD_PROFILE="${DR_UPLOAD_PROFILE}"
+  TARGET_S3_PREFIX="${DR_UPLOAD_S3_PREFIX}"
+else
+  TARGET_S3_BUCKET="${DR_LOCAL_S3_BUCKET}"
+  UPLOAD_PROFILE="${DR_LOCAL_PROFILE_ENDPOINT_URL}"
+  TARGET_S3_PREFIX="${MODEL_PREFIX}"
+fi
+
+if [[ -z "${OPT_FORCE}" ]]; then
+  echo "Ready to upload ${MODEL_PREFIX}.tar.gz to s3://${TARGET_S3_BUCKET}/${TARGET_S3_PREFIX}/${MODEL_PREFIX}.tar.gz"
+  read -r -p "Are you sure? [y/N] " response
+  if [[ ! "$response" =~ ^([yY][eE][sS]|[yY])$ ]]; then
+    echo "Aborting."
+    exit 1
+  fi
+fi
+
+aws ${UPLOAD_PROFILE} s3 cp "${CAR_ZIP_FILE}" \
+  "s3://${TARGET_S3_BUCKET}/${TARGET_S3_PREFIX}/${MODEL_PREFIX}.tar.gz"


### PR DESCRIPTION
This pull request refactors the process for creating and uploading a DeepRacer "car" model archive, improving usability, flexibility, and reliability. The main changes include introducing a new script to standardize car archive creation, updating the upload script to use this new process, and adding support for user-selectable checkpoints and model prefixes.

**Car archive creation and upload improvements:**

* Added a new script, `create-car-zip.sh`, which automates fetching model files from S3, selecting either the best or last checkpoint, and packaging them into a tar.gz archive with the correct structure for on-car use. This script includes robust error handling and flexible options for model prefix and output location.
* Refactored `upload-car.sh` to use `create-car-zip.sh` for generating the car archive, removing the previous logic that copied files directly from Docker containers. This ensures consistency and reliability in archive creation.
* Enhanced both scripts to support selecting the "best" or "last" checkpoint via a `-b` flag, and to allow specifying a model prefix with `-p`. This gives users more control over which model version is packaged and uploaded. [[1]](diffhunk://#diff-db818b908058ccb27f1147d904d1af2595126c3d1ae43bb53a8fcd6dc07c2248L4-R8) [[2]](diffhunk://#diff-db818b908058ccb27f1147d904d1af2595126c3d1ae43bb53a8fcd6dc07c2248L17-R32)
* Improved the upload process to allow targeting either the local or remote S3 bucket, with clearer prompts and confirmation steps for safety. The upload destination and S3 paths are now determined based on provided flags and environment variables.
* Updated usage instructions in both scripts to reflect the new options and workflow, improving clarity for users.